### PR TITLE
check error before recording an event

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,11 +62,10 @@ spec:
             value: $(WEBHOOK_SECRET_NAME)
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 100Mi
         ports:
         - containerPort: 9876
           name: webhook-server
@@ -104,7 +103,7 @@ data:
   config.json: |
      {
        "nodeSelector": {
-         "node-role.kubernetes.io/master": ""
+         "node-role.kubernetes.io/node": ""
        },
        "daemonsets": [
          {

--- a/pkg/nidhogg/handler.go
+++ b/pkg/nidhogg/handler.go
@@ -65,13 +65,14 @@ func (h *Handler) HandleNode(instance *corev1.Node) (reconcile.Result, error) {
 		instance = copy
 		log.Info("Updating Node taints", "instance", instance.Name, "taints added", taintChanges.taintsAdded, "taints removed", taintChanges.taintsRemoved)
 		err := h.Update(context.TODO(), instance)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
 		// this is a hack to make the event work on a non-namespaced object
 		copy.UID = types.UID(copy.Name)
 
 		h.recorder.Eventf(copy, corev1.EventTypeNormal, "TaintsChanged", "Taints added: %s, Taints removed: %s", taintChanges.taintsAdded, taintChanges.taintsRemoved)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
 	}
 
 	return reconcile.Result{}, nil


### PR DESCRIPTION
We should check wether the node got updated successfully before writing an event.

Also tweaked the example deployment with memory requests, node selector
 