### PR TITLE
handler: add annotation when the node is taintless

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Nidhogg is a controller that taints nodes based on whether a Pod from a specific
 
 Sometimes you have a Daemonset that is so important that you don't want other pods to run on your node until that Daemonset is up and running on the node. Nidhogg solves this problem by tainting the node until your Daemonset pod is ready, preventing pods that don't tolerate the taint from scheduling there.
 
+Nidhogg annotate the node when all the required taints are removed: `nidhogg.uswitch.com/first-time-ready: 2006-01-02T15:04:05Z`
+
 Nidhogg was built using [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder)
 
 ## Usage

--- a/pkg/nidhogg/handler.go
+++ b/pkg/nidhogg/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
@@ -18,9 +19,10 @@ import (
 )
 
 const (
-	taintKey              = "nidhogg.uswitch.com"
-	taintOperationAdded   = "added"
-	taintOperationRemoved = "removed"
+	taintKey                 = "nidhogg.uswitch.com"
+	taintOperationAdded      = "added"
+	taintOperationRemoved    = "removed"
+	annotationFirstTimeReady = taintKey + "/first-time-ready"
 )
 
 var (
@@ -96,9 +98,30 @@ func (h *Handler) HandleNode(instance *corev1.Node) (reconcile.Result, error) {
 		return reconcile.Result{}, fmt.Errorf("error caluclating taints for node: %v", err)
 	}
 
+	taintLess := true
+	for _, taint := range copy.Spec.Taints {
+		if strings.HasPrefix(taint.Key, taintKey) {
+			taintLess = false
+		}
+	}
+
+	var firstTimeReady string
+	if taintLess {
+		firstTimeReady = time.Now().Format("2006-01-02T15:04:05Z")
+		if copy.Annotations == nil {
+			copy.Annotations = map[string]string{
+				annotationFirstTimeReady: firstTimeReady,
+			}
+		} else if _, ok := copy.Annotations[annotationFirstTimeReady]; !ok {
+			copy.Annotations[annotationFirstTimeReady] = firstTimeReady
+		} else {
+			firstTimeReady = copy.Annotations[annotationFirstTimeReady]
+		}
+	}
+
 	if !reflect.DeepEqual(copy, instance) {
 		instance = copy
-		log.Info("Updating Node taints", "instance", instance.Name, "taints added", taintChanges.taintsAdded, "taints removed", taintChanges.taintsRemoved)
+		log.Info("Updating Node taints", "instance", instance.Name, "taints added", taintChanges.taintsAdded, "taints removed", taintChanges.taintsRemoved, "taintLess", taintLess, "firstTimeReady", firstTimeReady)
 		err := h.Update(context.TODO(), instance)
 		if err != nil {
 			taintOperationErrors.WithLabelValues("nodeUpdate").Inc()
@@ -114,7 +137,7 @@ func (h *Handler) HandleNode(instance *corev1.Node) (reconcile.Result, error) {
 		// this is a hack to make the event work on a non-namespaced object
 		copy.UID = types.UID(copy.Name)
 
-		h.recorder.Eventf(copy, corev1.EventTypeNormal, "TaintsChanged", "Taints added: %s, Taints removed: %s", taintChanges.taintsAdded, taintChanges.taintsRemoved)
+		h.recorder.Eventf(copy, corev1.EventTypeNormal, "TaintsChanged", "Taints added: %s, Taints removed: %s, TaintLess: %v, FirstTimeReady: %q", taintChanges.taintsAdded, taintChanges.taintsRemoved, taintLess, firstTimeReady)
 	}
 
 	return reconcile.Result{}, nil


### PR DESCRIPTION
I prepared this PR to ease the usage of any other components requiring the node being ready.

My use case is the cluster autoscaler who'll over scale because of the presence of the taints not in the node template (because added at runtime for obvious reason).

Let me know if my approach is adapted with **nidhogg**, I'm ready to rework this differently 👍 