### PR TITLE
handler: taint use the key value

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ JSON:
 }
 ```
 This example will taint any nodes that have the label `node-role.kubernetes.io/node=""` if they do not have a running and ready pod from the `kiam` daemonset in the `kube-system` namespace.
-It will add a taint of `nidhogg.uswitch.com/kube-system.kiam:NoSchedule` until there is a ready kiam pod on the node.
+It will add a taint of `nidhogg.uswitch.com=kube-system.kiam:NoSchedule` until there is a ready kiam pod on the node.
 
 If you want pods to be able to run on the nidhogg tainted nodes you can add a toleration:
 

--- a/pkg/nidhogg/handler.go
+++ b/pkg/nidhogg/handler.go
@@ -86,7 +86,7 @@ func (h *Handler) caclulateTaints(instance *corev1.Node) (*corev1.Node, taintCha
 
 	for _, daemonset := range h.config.Daemonsets {
 
-		taint := fmt.Sprintf("%s/%s.%s", taintKey, daemonset.Namespace, daemonset.Name)
+		taint := fmt.Sprintf("%s.%s", daemonset.Namespace, daemonset.Name)
 		// Get Pod for node
 		pod, err := h.getDaemonsetPod(instance.Name, daemonset)
 		if err != nil {
@@ -137,25 +137,28 @@ func podNotReady(pod *corev1.Pod) bool {
 	return false
 }
 
-func taintPresent(node *corev1.Node, taintName string) bool {
-
+func taintPresent(node *corev1.Node, taintValue string) bool {
 	for _, taint := range node.Spec.Taints {
-		if taint.Key == taintName {
+		if taint.Key == taintKey && taint.Value == taintValue {
 			return true
 		}
 	}
 	return false
 }
 
-func addTaint(taints []corev1.Taint, taintName string) []corev1.Taint {
-	return append(taints, corev1.Taint{Key: taintName, Effect: corev1.TaintEffectNoSchedule})
+func addTaint(taints []corev1.Taint, taintValue string) []corev1.Taint {
+	return append(taints, corev1.Taint{
+		Key:    taintKey,
+		Value:  taintValue,
+		Effect: corev1.TaintEffectNoSchedule,
+	})
 }
 
-func removeTaint(taints []corev1.Taint, taintName string) []corev1.Taint {
+func removeTaint(taints []corev1.Taint, taintValue string) []corev1.Taint {
 	newTaints := []corev1.Taint{}
 
 	for _, taint := range taints {
-		if taint.Key == taintName {
+		if taint.Key == taintKey && taint.Value == taintValue {
 			continue
 		}
 		newTaints = append(newTaints, taint)


### PR DESCRIPTION
This PR allows to use a more generic way to tolerate a group of keys instead of tolerating all the taints one by one.

What I'd like to do is tolerate `nidhogg.uswitch.com` taints in all the daemonsets I have like:

```yaml
tolerations:
  - key: nidhogg.uswitch.com
    operator: Exists
```
Instead of:
```yaml
tolerations:
  - key: nidhogg.uswitch.com/kube-system.kube-proxy
    operator: Exists
  - key: nidhogg.uswitch.com/node-local-dns.node-local-dns
    operator: Exists
  - key: nidhogg.uswitch.com/local-volume-provisioner.local-volume-provisioner
    operator: Exists
```

This allows us a more flexible way to manage nidhogg and our fleet of daemonsets.

Note:
As far as my tests went, it looks like the unicity of the taint must be across all keys 🤔 