### PR TITLE
controller: use a specific enqueue strategy

### DIFF
--- a/pkg/nidhogg/handler.go
+++ b/pkg/nidhogg/handler.go
@@ -117,6 +117,8 @@ func (h *Handler) HandleNode(instance *corev1.Node) (reconcile.Result, error) {
 		} else {
 			firstTimeReady = copy.Annotations[annotationFirstTimeReady]
 		}
+	} else if copy.Annotations != nil {
+		firstTimeReady = copy.Annotations[annotationFirstTimeReady]
 	}
 
 	if !reflect.DeepEqual(copy, instance) {


### PR DESCRIPTION
The current enqueue strategy of daemonset pods should add the `.spec.nodeName` instead of the controller `namespace/name` itself.

For example, with the following daemonset configuration:

```json
{
  "nodeSelector": {},
  "daemonsets": [
    {
      "name": "kube2iam",
      "namespace": "kube2iam"
    },
    {
      "name": "kube-proxy",
      "namespace": "kube-system"
    },
    {
      "name": "node-local-dns",
      "namespace": "coredns"
    },
    {
      "name": "local-volume-provisioner",
      "namespace": "local-volume-provisioner"
    }
  ]
}
```

All the daemonset are added to the queue and go to this [code path]( https://github.com/uswitch/nidhogg/blob/a8cc118a043b06aa520dccecdfaa4a5c01f170e0/pkg/controller/node/node_controller.go#L88-L92).
Because the node `local-volume-provisioner` is not found.

With this issue over large clusters, the queue depth of nidhogg stays too high and the controller, at 100%, could take up to 20 minutes to remove the taints while the required daemonset pods are effectively running.
```
# TYPE workqueue_depth gauge
workqueue_depth{name="node-controller"} 1929
```

The is the instrumented nidhogg profile:
![image](https://user-images.githubusercontent.com/8077192/71821468-84d2fe00-3092-11ea-99d5-81a2f4da64fb.png)

This is the profile with this PR as patch and 3 concurrent reconcilers (default to 1):
![image](https://user-images.githubusercontent.com/8077192/71821645-ebf0b280-3092-11ea-963e-847a70b96151.png)

### Nodes

**Create:**
From what I observed, it's interesting to process new `Create` node to add immediately the taint


### Pods

**Create:**
Daemonsets managed by the `kube-controller-manager` has their `.spec.nodeName` already set when created.

**Update/Delete:**
Any transition of phase would be interesting to catch there.