### PR TITLE
handler: fix use of copy instead of node copy

### DIFF
--- a/pkg/nidhogg/handler.go
+++ b/pkg/nidhogg/handler.go
@@ -117,8 +117,8 @@ func (h *Handler) HandleNode(instance *corev1.Node) (reconcile.Result, error) {
 		} else {
 			firstTimeReady = nodeCopy.Annotations[annotationFirstTimeReady]
 		}
-	} else if copy.Annotations != nil {
-		firstTimeReady = copy.Annotations[annotationFirstTimeReady]
+	} else if nodeCopy.Annotations != nil {
+		firstTimeReady = nodeCopy.Annotations[annotationFirstTimeReady]
 	}
 
 	if !reflect.DeepEqual(nodeCopy, instance) {


### PR DESCRIPTION
Not quite sure how our tests didn't catch this the first time, perhaps a webhook didn't fire?
Wrong variable name is used in the code here, fixed.