### PR TITLE
Use selector expressions rather than simple label matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Example:
 YAML:
 ```yaml
 nodeSelector:
-  node-role.kubernetes.io/node: ""
+  node-role.kubernetes.io/node
 daemonsets:
   - name: kiam
     namespace: kube-system  
@@ -27,9 +27,11 @@ JSON:
 
 ```json
 {
-  "nodeSelector": {
-    "node-role.kubernetes.io/node": ""
-  },
+  "nodeSelector": [
+    "node-role.kubernetes.io/node",
+    "!node-role.kubernetes.io/master",
+    "aws.amazon.com/ec2.asg.name in (standard, special)"
+  ],
   "daemonsets": [
     {
       "name": "kiam",
@@ -38,8 +40,10 @@ JSON:
   ]
 }
 ```
-This example will taint any nodes that have the label `node-role.kubernetes.io/node=""` if they do not have a running and ready pod from the `kiam` daemonset in the `kube-system` namespace.
-It will add a taint of `nidhogg.uswitch.com/kube-system.kiam:NoSchedule` until there is a ready kiam pod on the node.
+This example will select any nodes in AWS ASGs named "standard" or "special" that have the label 
+`node-role.kubernetes.io/node` present, and no nodes with label `node-role.kubernetes.io/master`. If the matching nodes 
+do not have a running and ready pod from the `kiam` daemonset in the `kube-system` namespace. It will add a taint of 
+`nidhogg.uswitch.com/kube-system.kiam:NoSchedule` until there is a ready kiam pod on the node.
 
 If you want pods to be able to run on the nidhogg tainted nodes you can add a toleration:
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -55,7 +55,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Info(handlerConf.Selector.String())
+	log.Info("looking for nodes that match selector", handlerConf.Selector.String())
 
 	// Get a config to talk to the apiserver
 	log.Info("setting up client for manager")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -55,6 +55,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	log.Info(handlerConf.Selector.String())
+
 	// Get a config to talk to the apiserver
 	log.Info("setting up client for manager")
 	cfg, err := config.GetConfig()

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -102,9 +102,9 @@ metadata:
 data:
   config.json: |
      {
-       "nodeSelector": {
-         "node-role.kubernetes.io/node": ""
-       },
+       "nodeSelector": [
+         "node-role.kubernetes.io/node"
+       ],
        "daemonsets": [
          {
            "name": "kiam",

--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -47,7 +47,10 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
-	recFn, requests := SetupTestReconcile(newReconciler(mgr, nidhogg.HandlerConfig{}))
+	handler := nidhogg.HandlerConfig{}
+	handler.BuildSelectors()
+
+	recFn, requests := SetupTestReconcile(newReconciler(mgr, handler))
 	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
 
 	stopMgr, mgrStopped := StartTestManager(mgr, g)

--- a/pkg/nidhogg/decoder.go
+++ b/pkg/nidhogg/decoder.go
@@ -21,6 +21,8 @@ func GetConfig(config string) (HandlerConfig, error) {
 		return HandlerConfig{}, fmt.Errorf("error parsing file: %v", err)
 	}
 
+	handlerConf.BuildSelectors()
+
 	return handlerConf, nil
 
 }

--- a/pkg/nidhogg/decoder.go
+++ b/pkg/nidhogg/decoder.go
@@ -21,7 +21,9 @@ func GetConfig(config string) (HandlerConfig, error) {
 		return HandlerConfig{}, fmt.Errorf("error parsing file: %v", err)
 	}
 
-	handlerConf.BuildSelectors()
+	if err := handlerConf.BuildSelectors(); err != nil {
+		return HandlerConfig{}, err
+	}
 
 	return handlerConf, nil
 

--- a/pkg/nidhogg/handler.go
+++ b/pkg/nidhogg/handler.go
@@ -66,16 +66,17 @@ type HandlerConfig struct {
 	Selector     labels.Selector
 }
 
-func (hc *HandlerConfig) BuildSelectors() {
+func (hc *HandlerConfig) BuildSelectors() error {
 	hc.Selector = labels.Everything()
 	for _, rawSelector := range hc.NodeSelector {
 		if selector, err := labels.Parse(rawSelector); err != nil {
-			panic(err)
+			return fmt.Errorf("error parsing selector: %v", err)
 		} else {
 			requirements, _ := selector.Requirements()
 			hc.Selector = hc.Selector.Add(requirements...)
 		}
 	}
+	return nil
 }
 
 // Daemonset contains the name and namespace of a Daemonset

--- a/pkg/nidhogg/handler.go
+++ b/pkg/nidhogg/handler.go
@@ -61,8 +61,22 @@ type Handler struct {
 
 // HandlerConfig contains the options for Nidhogg
 type HandlerConfig struct {
-	Daemonsets   []Daemonset       `json:"daemonsets" yaml:"daemonsets"`
-	NodeSelector map[string]string `json:"nodeSelector" yaml:"nodeSelector"`
+	Daemonsets   []Daemonset `json:"daemonsets" yaml:"daemonsets"`
+	NodeSelector []string    `json:"nodeSelector" yaml:"nodeSelector"`
+	Selector     labels.Selector
+}
+
+func (hc *HandlerConfig) BuildSelectors() {
+	print("test")
+	hc.Selector = labels.Everything()
+	for _, rawSelector := range hc.NodeSelector {
+		if selector, err := labels.Parse(rawSelector); err != nil {
+			panic(err)
+		} else {
+			requirements, _ := selector.Requirements()
+			hc.Selector = hc.Selector.Add(requirements...)
+		}
+	}
 }
 
 // Daemonset contains the name and namespace of a Daemonset
@@ -87,8 +101,7 @@ func (h *Handler) HandleNode(instance *corev1.Node) (reconcile.Result, error) {
 	log := logf.Log.WithName("nidhogg")
 
 	//check whether node matches the nodeSelector
-	selector := labels.SelectorFromSet(h.config.NodeSelector)
-	if !selector.Matches(labels.Set(instance.Labels)) {
+	if !h.config.Selector.Matches(labels.Set(instance.Labels)) {
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/nidhogg/handler.go
+++ b/pkg/nidhogg/handler.go
@@ -67,7 +67,6 @@ type HandlerConfig struct {
 }
 
 func (hc *HandlerConfig) BuildSelectors() {
-	print("test")
 	hc.Selector = labels.Everything()
 	for _, rawSelector := range hc.NodeSelector {
 		if selector, err := labels.Parse(rawSelector); err != nil {


### PR DESCRIPTION
closes #25 

This allows the use of selector expressions that are compiled into a single selector. From `k8s.io/apimachinery/pkg/labels/selector.go`:

```
// Parse takes a string representing a selector and returns a selector
// object, or an error. This parsing function differs from ParseSelector
// as they parse different selectors with different syntaxes.
// The input will cause an error if it does not follow this form:
//
//  <selector-syntax>         ::= <requirement> | <requirement> "," <selector-syntax>
//  <requirement>             ::= [!] KEY [ <set-based-restriction> | <exact-match-restriction> ]
//  <set-based-restriction>   ::= "" | <inclusion-exclusion> <value-set>
//  <inclusion-exclusion>     ::= <inclusion> | <exclusion>
//  <exclusion>               ::= "notin"
//  <inclusion>               ::= "in"
//  <value-set>               ::= "(" <values> ")"
//  <values>                  ::= VALUE | VALUE "," <values>
//  <exact-match-restriction> ::= ["="|"=="|"!="] VALUE
//
// KEY is a sequence of one or more characters following [ DNS_SUBDOMAIN "/" ] DNS_LABEL. Max length is 63 characters.
// VALUE is a sequence of zero or more characters "([A-Za-z0-9_-\.])". Max length is 63 characters.
// Delimiter is white space: (' ', '\t')
// Example of valid syntax:
//  "x in (foo,,baz),y,z notin ()"
//
// Note:
//  (1) Inclusion - " in " - denotes that the KEY exists and is equal to any of the
//      VALUEs in its requirement
//  (2) Exclusion - " notin " - denotes that the KEY is not equal to any
//      of the VALUEs in its requirement or does not exist
//  (3) The empty string is a valid VALUE
//  (4) A requirement with just a KEY - as in "y" above - denotes that
//      the KEY exists and can be any VALUE.
//  (5) A requirement with just !KEY requires that the KEY not exist.
//
```