### PR TITLE
Update rbac_role.yaml

### DIFF
--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:


### PR DESCRIPTION
removed null Timestamp. this was causing a failure in creating the ClusterRole on EKS v1.19